### PR TITLE
Phase 9a: add Slack notification for uptime alerts

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -157,8 +157,8 @@ assignees:
 # See full list: https://upptime.js.org/docs/notifications
 
 notifications:
-  # - type: slack
-  #   webhookUrl: ${{ secrets.SLACK_WEBHOOK_URL }}
+  - type: slack
+    webhookUrl: $SLACK_WEBHOOK_URL
   # - type: discord
   #   webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
   # - type: email

--- a/history/allgrid.yml
+++ b/history/allgrid.yml
@@ -1,7 +1,7 @@
 url: https://allgrid.com/
 status: up
 code: 200
-responseTime: 2452
-lastUpdated: 2026-05-04T11:40:38.626Z
+responseTime: 1720
+lastUpdated: 2026-05-04T12:24:38.311Z
 startTime: 2026-04-20T07:09:46.359Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/build-a-barn.yml
+++ b/history/build-a-barn.yml
@@ -1,7 +1,7 @@
 url: https://bildabarn.com/
 status: up
 code: 200
-responseTime: 86
-lastUpdated: 2026-05-04T07:25:00.069Z
+responseTime: 197
+lastUpdated: 2026-05-04T12:24:39.380Z
 startTime: 2026-04-20T07:09:54.122Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/call-big-red.yml
+++ b/history/call-big-red.yml
@@ -1,7 +1,7 @@
 url: https://callbigred.com/
 status: up
 code: 200
-responseTime: 563
-lastUpdated: 2026-05-04T07:25:01.542Z
+responseTime: 794
+lastUpdated: 2026-05-04T12:24:41.173Z
 startTime: 2026-04-20T07:09:56.940Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/dryer-vent-guardian.yml
+++ b/history/dryer-vent-guardian.yml
@@ -1,7 +1,7 @@
 url: https://dryerventguardian.com/
 status: up
 code: 200
-responseTime: 119
-lastUpdated: 2026-05-04T07:25:00.770Z
+responseTime: 214
+lastUpdated: 2026-05-04T12:24:40.176Z
 startTime: 2026-04-20T07:09:56.331Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/equinavia.yml
+++ b/history/equinavia.yml
@@ -1,7 +1,7 @@
 url: https://equinavia.com/
 status: up
 code: 200
-responseTime: 628
-lastUpdated: 2026-05-04T07:24:54.632Z
+responseTime: 864
+lastUpdated: 2026-05-04T12:24:34.679Z
 startTime: 2026-04-20T06:24:19.389Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/gutta-staging.yml
+++ b/history/gutta-staging.yml
@@ -1,7 +1,7 @@
 url: https://staging.gutta.no
 status: up
 code: 200
-responseTime: 573
-lastUpdated: 2026-05-04T07:25:02.642Z
+responseTime: 336
+lastUpdated: 2026-05-04T12:24:42.032Z
 startTime: 2026-05-04T07:25:02.065Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/i-love-pole-buildings.yml
+++ b/history/i-love-pole-buildings.yml
@@ -1,7 +1,7 @@
 url: https://ilovepolebuildings.com/
 status: up
 code: 200
-responseTime: 91
-lastUpdated: 2026-05-04T07:24:59.491Z
+responseTime: 141
+lastUpdated: 2026-05-04T12:24:38.651Z
 startTime: 2026-04-20T07:09:52.853Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/i-trust-quality.yml
+++ b/history/i-trust-quality.yml
@@ -1,7 +1,7 @@
 url: https://www.itrustquality.com/
 status: up
 code: 200
-responseTime: 173
-lastUpdated: 2026-05-04T07:25:00.447Z
+responseTime: 184
+lastUpdated: 2026-05-04T12:24:39.765Z
 startTime: 2026-04-20T07:09:55.723Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/nordic-fund-day.yml
+++ b/history/nordic-fund-day.yml
@@ -1,7 +1,7 @@
 url: https://nordicfundday.no/
 status: up
 code: 200
-responseTime: 1361
-lastUpdated: 2026-05-04T07:24:53.795Z
+responseTime: 1242
+lastUpdated: 2026-05-04T12:24:33.619Z
 startTime: 2026-04-20T06:24:17.704Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/preikestolen-basecamp.yml
+++ b/history/preikestolen-basecamp.yml
@@ -1,7 +1,7 @@
 url: https://preikestolenbasecamp.com/
 status: up
 code: 200
-responseTime: 1815
-lastUpdated: 2026-05-04T07:24:56.649Z
+responseTime: 1522
+lastUpdated: 2026-05-04T12:24:36.391Z
 startTime: 2026-04-20T07:09:44.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/septic-masters.yml
+++ b/history/septic-masters.yml
@@ -1,7 +1,7 @@
 url: https://septic-masters.com/
 status: up
 code: 200
-responseTime: 79
-lastUpdated: 2026-05-04T07:24:59.782Z
+responseTime: 126
+lastUpdated: 2026-05-04T12:24:38.982Z
 startTime: 2026-04-20T07:09:53.468Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/wood-rock-engineering.yml
+++ b/history/wood-rock-engineering.yml
@@ -1,7 +1,7 @@
 url: https://woodrockengineering.com/
 status: up
 code: 200
-responseTime: 107
-lastUpdated: 2026-05-04T07:25:01.861Z
+responseTime: 116
+lastUpdated: 2026-05-04T12:24:41.487Z
 startTime: 2026-04-20T07:09:58.059Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Summary

- Uncomments and activates the pre-existing Slack notification block in `.upptimerc.yml`
- Fixes secret reference syntax: `${{ secrets.SLACK_WEBHOOK_URL }}` → `$SLACK_WEBHOOK_URL` (Upptime's native format)
- Posts to **#kw-uptime-alerts** on every site state transition (down/recovered)

## Test plan

- [ ] Merge PR
- [ ] Trigger Uptime CI manually: `gh workflow run "Uptime CI" --repo Kilowott-HQ/uptime`
- [ ] Add smoketest fake URL → confirm Slack "Down" alert arrives
- [ ] Remove smoketest URL → confirm Slack "Recovered" alert arrives
- [ ] Verify no Slack noise on healthy sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)