### PR TITLE
test: flip smoketest URL to .invalid — triggers Slack down alert (Phase 9a)

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://kilowott.com
+    url: https://this-domain-does-not-exist-kilowott-9a.invalid
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
## Context

Smoketest history now shows `status: up` for `kilowott.com`. This PR flips it back to the unreachable `.invalid` domain.

## Expected outcome after merge + CI run

Upptime detects: **up → down** transition → fires Slack notification to **#kw-uptime-alerts**

## After Slack confirmed

Merge the cleanup PR (`phase-9a-cleanup`) to remove the smoketest entry entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)