### PR TITLE
fix(uptime): force Node 20 runtime to unblock Upptime CI

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,6 +21,14 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
+# Force runner to use Node 20 for Upptime's actions.
+# Upstream upptime/uptime-monitor v1.41.1 ships a node-libcurl native binding
+# compiled against NODE_MODULE_VERSION 115 (Node 20). The runner forced Node 24
+# (NODE_MODULE_VERSION 127) earlier than expected, breaking the action.
+# This override keeps Node 20 until Upptime ships a Node 24-compatible release.
+# Re-apply after each Upptime template-update run, which regenerates this file.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 jobs:
   release:
     name: Check status


### PR DESCRIPTION
## Problem

Every Uptime CI run since **2026-05-05 04:12 UTC** has failed with a native module incompatibility:

\`\`\`
Error: The module 'node_libcurl.node' was compiled against a different Node.js
version. NODE_MODULE_VERSION 127 (Node 24). This version of Node.js requires
NODE_MODULE_VERSION 115 (Node 20).
\`\`\`

GitHub Actions runner started forcing Node 24 ahead of the announced 2026-06-02
cutover. Upstream \`upptime/uptime-monitor@v1.41.1\` still ships its
\`node-libcurl\` binding compiled against Node 20.

## Fix

Set \`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true\` at the workflow env level
to opt back into Node 20.

## Known limitation

Upptime's \`update-template.yml\` regenerates \`uptime.yml\` weekly. The fix
will need re-applying after each template update. Permanent fix: wait for an
Upptime release with a Node 24-compatible \`node-libcurl\` build.

## Test plan

- [ ] Merge PR
- [ ] Trigger Uptime CI manually
- [ ] Verify run succeeds and \`phase-9a-smoketest-will-be-removed\` flips up→down
- [ ] Confirm Slack alert arrives in #kw-uptime-alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)