### PR TITLE
fix(uptime): pin uptime-monitor@v1.41.0, revert ineffective env var

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,14 +21,6 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
-# Force runner to use Node 20 for Upptime's actions.
-# Upstream upptime/uptime-monitor v1.41.1 ships a node-libcurl native binding
-# compiled against NODE_MODULE_VERSION 115 (Node 20). The runner forced Node 24
-# (NODE_MODULE_VERSION 127) earlier than expected, breaking the action.
-# This override keeps Node 20 until Upptime ships a Node 24-compatible release.
-# Re-apply after each Upptime template-update run, which regenerates this file.
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 jobs:
   release:
     name: Check status
@@ -40,7 +32,12 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.1
+        # Pinned to v1.41.0 — v1.41.1's node-libcurl binding is compiled
+        # against NODE_MODULE_VERSION 115 (Node 20) and breaks on the
+        # current runner (Node 24, NODE_MODULE_VERSION 127). v1.41.0 was
+        # the last version that ran successfully (04:10 UTC 2026-05-05).
+        # Will need re-pinning after each Upptime template-update run.
+        uses: upptime/uptime-monitor@v1.41.0
         with:
           command: "update"
         env:


### PR DESCRIPTION
## Why this PR

PR #17's \`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true\` override **did not work** — runs at 04:39 UTC still failed with the same \`NODE_MODULE_VERSION 115 vs 127\` error. That env var is for opting Node 16 actions into Node 20 runs; it does not coerce a Node 20 action onto a Node 24 runtime.

## Real cause

PR #15's merge brought \`upptime/uptime-monitor@v1.41.1\` into the workflow (master had drifted to v1.41.1 via an Upptime template-update commit before our smoketest branch landed). v1.41.1's \`node-libcurl\` binding is incompatible with the runner's current Node 24.

Last successful run: \`25357380721\` at 04:10:19 UTC, on v1.41.0.

## What this changes

- Pins \`upptime-monitor\` to **v1.41.0** with an inline comment explaining why
- Reverts the env-var override from PR #17 (no effect, just clutter)

## Known limitation

Upptime's \`update-template.yml\` regenerates this file weekly and will likely re-bump to v1.41.1+. Re-apply pin after each template update, or unpin once Upptime ships a Node 24-compatible release.

## Test plan

- [ ] Merge
- [ ] Trigger Uptime CI manually
- [ ] Confirm run succeeds (no NODE_MODULE_VERSION error)
- [ ] Confirm Slack alert arrives in #kw-uptime-alerts on smoketest up→down

🤖 Generated with [Claude Code](https://claude.com/claude-code)