### PR TITLE
Phase 9a debug: brace-syntax for webhook + temp debug echo

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -31,6 +31,22 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Debug — confirm SLACK_WEBHOOK_URL is reaching runner
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "WEBHOOK IS EMPTY"
+            exit 1
+          else
+            echo "WEBHOOK PREFIX: ${SLACK_WEBHOOK_URL:0:40}"
+            echo "WEBHOOK LENGTH: ${#SLACK_WEBHOOK_URL}"
+            if [[ "$SLACK_WEBHOOK_URL" == https://hooks.slack.com/* ]]; then
+              echo "WEBHOOK STARTS WITH https://hooks.slack.com: YES"
+            else
+              echo "WEBHOOK STARTS WITH https://hooks.slack.com: NO"
+            fi
+          fi
       - name: Check endpoint status
         # Pinned to v1.41.0 — v1.41.1's node-libcurl binding is compiled
         # against NODE_MODULE_VERSION 115 (Node 20) and breaks on the

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -162,7 +162,7 @@ assignees:
 
 notifications:
   - type: slack
-    webhookUrl: $SLACK_WEBHOOK_URL
+    webhookUrl: ${SLACK_WEBHOOK_URL}
   # - type: discord
   #   webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
   # - type: email


### PR DESCRIPTION
## Why this PR

Upptime's last run logged \`Sending notification ... is **down**\` but no Slack message arrived in #kw-uptime-alerts. Manual POST to the same webhook URL works. Bug is between Upptime reading \`.upptimerc.yml\` and constructing the POST URL.

## What this changes

1. \`.upptimerc.yml\`: \`$SLACK_WEBHOOK_URL\` → \`\${SLACK_WEBHOOK_URL}\` (some Upptime versions only expand the bash-bracket form)
2. \`uptime.yml\`: temp debug step that prints first 40 chars + length + scheme of the secret right before Upptime runs

## Diagnostic outcomes

After merge + rearm + Uptime CI run:

- **Empty/wrong webhook value**: secret didn't propagate or is corrupted
- **Correct webhook value + brace fix worked**: Slack arrives → done
- **Correct webhook value + still no Slack**: deeper bug in Upptime, surface logs

## Cleanup

Debug echo will be removed in a follow-up PR once we have proof the secret value is correct on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)