### PR TITLE
feat(notify): workflow-level Slack notifier (bypass broken Upptime module)

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -47,6 +47,10 @@ jobs:
               echo "WEBHOOK STARTS WITH https://hooks.slack.com: NO"
             fi
           fi
+      - name: Capture starting SHA
+        id: pre_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - name: Check endpoint status
         # Pinned to v1.41.0 — v1.41.1's node-libcurl binding is compiled
         # against NODE_MODULE_VERSION 115 (Node 20) and breaks on the
@@ -59,3 +63,34 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
+
+      - name: Notify Slack on state changes
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          START_SHA="${{ steps.pre_sha.outputs.sha }}"
+          git pull --rebase --quiet
+          changes=$(git log "${START_SHA}..HEAD" --pretty=format:"%H|%s" | grep -E '\[upptime\]$' || true)
+          if [ -z "$changes" ]; then
+            echo "No state-change commits — nothing to notify"
+            exit 0
+          fi
+          failed=0
+          while IFS='|' read -r sha subject; do
+            [ -z "$sha" ] && continue
+            clean="${subject% \[upptime\]}"
+            commit_url="https://github.com/${{ github.repository }}/commit/${sha}"
+            payload=$(jq -n --arg text "$(printf '*%s*\n%s' "${clean}" "${commit_url}")" '{"text": $text}')
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "${payload}")
+            echo "[notify] ${clean} → HTTP ${http_code}"
+            if [ "${http_code}" != "200" ]; then
+              failed=$((failed + 1))
+            fi
+          done <<< "${changes}"
+          if [ "${failed}" -gt 0 ]; then
+            exit 1
+          fi

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -160,17 +160,13 @@ assignees:
 #
 # See full list: https://upptime.js.org/docs/notifications
 
-notifications:
-  - type: slack
-    webhookUrl: ${SLACK_WEBHOOK_URL}
-  # - type: discord
-  #   webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
-  # - type: email
-  #   service: ${{ secrets.SMTP_SERVICE }}
-  #   user: ${{ secrets.SMTP_USER }}
-  #   pass: ${{ secrets.SMTP_PASS }}
-  #   from: status@kilowott.com
-  #   to: ops@kilowott.com
+# Notifications are handled at the workflow level (uptime.yml "Notify Slack" step)
+# rather than via Upptime's built-in module, which silently drops POSTs in v1.41.x.
+# See .github/workflows/uptime.yml — "Notify Slack on state changes" step.
+#
+# notifications:
+#   - type: slack
+#     webhookUrl: ${SLACK_WEBHOOK_URL}
 
 # ----------------------------------------------------------------------
 # i18n


### PR DESCRIPTION
## What

Replaces Upptime's native Slack integration (silently broken in v1.41.x) with a workflow-level notify step.

## How it works

1. **Capture starting SHA** — recorded before `uptime-monitor` runs
2. **Check endpoint status** — Upptime runs as before, commits state changes with messages like `🟥 Nordic Fund Day is down [upptime]`
3. **Notify Slack on state changes** (`if: always()`) — after Upptime finishes:
   - `git pull --rebase --quiet` to pick up any new commits
   - `git log START_SHA..HEAD` filtered by `\[upptime\]$` suffix
   - For each match: strip `[upptime]`, POST `*🟥 Site is down*\n<commit URL>` to `SLACK_WEBHOOK_URL`
   - Logs `[notify] <message> → HTTP <code>` per send
   - Exits 1 if any POST returns non-200 (run shows red)

## Also

- Disables `.upptimerc.yml` `notifications:` block (commented out with explanation) so Upptime stops attempting its broken native send

## Test plan

- [ ] Merge → CI runs → rearm-up (flip smoketest to kilowott.com) → confirm `[notify] ... → HTTP 200` in logs + Slack message arrives
- [ ] Rearm-down (flip back to `.invalid`) → confirm down alert in Slack
- [ ] Cleanup PR: remove debug echo step + smoketest entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)