### PR TITLE
rearm: smoketest up (kilowott.com) — establish up state for v2 notify test

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://this-domain-does-not-exist-kilowott-9a.invalid
+    url: https://kilowott.com/
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
Flip smoketest URL to kilowott.com so next CI run records it as up. This establishes state history needed for the rearm-down step to trigger a 🟩 → 🟥 transition and fire the new workflow-level Slack notifier.