### PR TITLE
fix(notify): filter to emoji-prefixed state-change commits only

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           START_SHA="${{ steps.pre_sha.outputs.sha }}"
           git pull --rebase --quiet
-          changes=$(git log "${START_SHA}..HEAD" --pretty=format:"%H|%s" | grep -E '\[upptime\]$' || true)
+          changes=$(git log "${START_SHA}..HEAD" --pretty=format:"%H|%s" | grep -E '^(🟥|🟩|🟨).*\[upptime\]$' || true)
           if [ -z "$changes" ]; then
             echo "No state-change commits — nothing to notify"
             exit 0


### PR DESCRIPTION
Summary/README commits from Upptime also end with `[upptime]` so the original grep fired spurious Slack messages for every CI run.

Fix: add emoji prefix anchor `^(🟥|🟩|🟨)` so only real down/up/degraded transitions send alerts.

One-line diff: `grep -E '^\(🟥|🟩|🟨\).*\[upptime\]$'`