### PR TITLE
rearm: smoketest down — trigger 🟥 alert to verify grep fix

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://kilowott.com/
+    url: https://this-domain-does-not-exist-kilowott-9a.invalid
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
Flip smoketest URL back to `.invalid` to force a down state transition. This verifies the fixed grep (emoji-prefix anchor) fires exactly one 🟥 Slack message with no spurious noise.