### PR TITLE
fix(notify): git fetch + origin/master instead of pull --rebase on detached HEAD

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -70,8 +70,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           START_SHA="${{ steps.pre_sha.outputs.sha }}"
-          git pull --rebase --quiet
-          changes=$(git log "${START_SHA}..HEAD" --pretty=format:"%H|%s" | grep -E '^(🟥|🟩|🟨).*\[upptime\]$' || true)
+          git fetch origin master --quiet
+          changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '^(🟥|🟩|🟨).*\[upptime\]$' || true)
           if [ -z "$changes" ]; then
             echo "No state-change commits — nothing to notify"
             exit 0


### PR DESCRIPTION
**Root cause:** `actions/checkout@v4` with `ref: ${{ github.head_ref }}` produces a **detached HEAD** on `workflow_dispatch` / `schedule` events (head_ref is empty). `git pull --rebase` on a detached HEAD is a no-op — HEAD stays at START_SHA, so `git log START_SHA..HEAD` is always empty.

**Fix:** Replace `git pull --rebase --quiet` + `..HEAD` with `git fetch origin master --quiet` + `..origin/master`. Works regardless of HEAD state.

The 🟥 commit for the smoketest *was* pushed to master by Upptime; only the notify step failed to see it.