### PR TITLE
rearm: smoketest up — verify 🟩 alert fires with fetch-fix

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://this-domain-does-not-exist-kilowott-9a.invalid
+    url: https://kilowott.com/
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
Flip smoketest to kilowott.com. Next CI run should commit `🟩 Phase 9a smoketest is up` and the notify step should POST exactly one message to Slack.