### PR TITLE
fix(notify): git fetch origin (no refspec) to correctly update origin/master

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -70,7 +70,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           START_SHA="${{ steps.pre_sha.outputs.sha }}"
-          git fetch origin master --quiet
+          git fetch origin --quiet
           changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '^(🟥|🟩|🟨).*\[upptime\]$' || true)
           if [ -z "$changes" ]; then
             echo "No state-change commits — nothing to notify"


### PR DESCRIPTION
**Bug:** `git fetch origin master` writes to `FETCH_HEAD` only — it does **not** update `refs/remotes/origin/master`. So `git log START_SHA..origin/master` was comparing against the stale pre-run ref (= START_SHA), making the range always empty.

**Fix:** `git fetch origin` (no refspec) updates all remote-tracking refs including `origin/master`, so the log range correctly spans from checkout SHA to the commits Upptime just pushed.