### PR TITLE
rearm: smoketest down — final 🟥 verification with all fixes in place

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://kilowott.com/
+    url: https://this-domain-does-not-exist-kilowott-9a.invalid
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
Flip smoketest to `.invalid`. This will cause Upptime to commit `🟥 Phase 9a smoketest is down` and the notify step (with all three fixes applied) should POST exactly one message to Slack.