### PR TITLE
fix(notify): locale-safe grep — filter colon-prefixed commits instead of emoji match

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           START_SHA="${{ steps.pre_sha.outputs.sha }}"
           git fetch origin --quiet
-          changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '^(🟥|🟩|🟨).*\[upptime\]$' || true)
+          changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '\[upptime\]$' | grep -v '^:' || true)
           if [ -z "$changes" ]; then
             echo "No state-change commits — nothing to notify"
             exit 0


### PR DESCRIPTION
**Root cause:** `grep -E '^(🟥|🟩|🟨)'` does not match on the Actions runner — literal UTF-8 emoji in ERE patterns fail silently due to locale/encoding mismatch (confirmed via `cat -v` showing the bytes are valid F0 9F 9F A5/A9, but grep still doesn't fire).

**Fix:** Invert the filter. Upptime's non-state-change commits (`Update status summary`, `Update summary in README`) always start with `:` (text emoji shortcode like `:card_file_box:`). State-change commits start with actual Unicode emoji. So `grep -v '^:'` excludes the noise without touching emoji bytes.

Pattern: `grep -E '\[upptime\]$' | grep -v '^:'`