### PR TITLE
fix(notify): grep -v '|:' — line starts with SHA, colon is after the pipe

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           START_SHA="${{ steps.pre_sha.outputs.sha }}"
           git fetch origin --quiet
-          changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '\[upptime\]$' | grep -v '^:' || true)
+          changes=$(git log "${START_SHA}..origin/master" --pretty=format:"%H|%s" | grep -E '\[upptime\]$' | grep -v '|:' || true)
           if [ -z "$changes" ]; then
             echo "No state-change commits — nothing to notify"
             exit 0


### PR DESCRIPTION
**Bug:** `%H|%s` puts the SHA hex first then `|` then the subject. So lines look like `abc123def|:card_file_box: ...`. `grep -v '^:'` never matches because lines start with the SHA, not the colon.

**Fix:** Match `|:` (the colon immediately after the pipe separator) to exclude commits whose subject starts with a colon — i.e. the `:card_file_box:` and `:pencil:` summary commits.