### PR TITLE
rearm: smoketest down — final 🟥 single-message verification

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -94,7 +94,7 @@ sites:
     url: https://staging.gutta.no
 
   - name: Phase 9a smoketest (will be removed)
-    url: https://kilowott.com/
+    url: https://this-domain-does-not-exist-kilowott-9a.invalid
     tags: [smoketest]
 
   # --- Add more sites below as you expand coverage ---


### PR DESCRIPTION
Flip smoketest to .invalid. Next CI run should fire EXACTLY ONE 🟥 message in #kw-uptime-alerts (no summary/README noise this time).