### PR TITLE
chore(phase-9a): cleanup — concurrency control + drop debug + remove smoketest

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,6 +21,13 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
+
+# Serialize uptime runs so concurrent dispatches/schedules can't both
+# observe the same state-change commit window and double-notify Slack.
+concurrency:
+  group: uptime-ci
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Check status
@@ -31,22 +38,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
-      - name: Debug — confirm SLACK_WEBHOOK_URL is reaching runner
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "WEBHOOK IS EMPTY"
-            exit 1
-          else
-            echo "WEBHOOK PREFIX: ${SLACK_WEBHOOK_URL:0:40}"
-            echo "WEBHOOK LENGTH: ${#SLACK_WEBHOOK_URL}"
-            if [[ "$SLACK_WEBHOOK_URL" == https://hooks.slack.com/* ]]; then
-              echo "WEBHOOK STARTS WITH https://hooks.slack.com: YES"
-            else
-              echo "WEBHOOK STARTS WITH https://hooks.slack.com: NO"
-            fi
-          fi
       - name: Capture starting SHA
         id: pre_sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -93,10 +93,6 @@ sites:
   - name: Gutta Staging
     url: https://staging.gutta.no
 
-  - name: Phase 9a smoketest (will be removed)
-    url: https://this-domain-does-not-exist-kilowott-9a.invalid
-    tags: [smoketest]
-
   # --- Add more sites below as you expand coverage ---
   #
   # TEMPLATE for production sites:

--- a/history/phase-9a-smoketest-will-be-removed.yml
+++ b/history/phase-9a-smoketest-will-be-removed.yml
@@ -1,7 +1,0 @@
-url: https://this-domain-does-not-exist-kilowott-9a.invalid
-status: down
-code: 0
-responseTime: 0
-lastUpdated: 2026-05-05T06:30:32.785Z
-startTime: 2026-05-04T12:26:45.996Z
-generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Phase 9a wrap-up. Three changes:

1. **Concurrency control on workflow** — `concurrency: { group: uptime-ci, cancel-in-progress: false }` so two near-simultaneous runs (e.g. manual dispatch landing on a scheduled cron) can't both observe the same state-change commit window and send duplicate Slack alerts. The 12:01 PM duplicate this morning was caused by exactly that race.

2. **Drop the SLACK_WEBHOOK_URL debug echo step** — it was diagnostic for the originally-broken Upptime native module. Pipeline is now verified end-to-end (HTTP 200 + clean Slack messages on both 🟩 and 🟥 transitions).

3. **Remove Phase 9a smoketest** — drop the `https://...invalid` site entry from `.upptimerc.yml` and its history file (`history/phase-9a-smoketest-will-be-removed.yml`). No longer needed.

After this lands, the uptime monitor is in its production-ready state.