### PR TITLE
feat(notify): page @channel on down/degraded only

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -72,7 +72,14 @@ jobs:
             [ -z "$sha" ] && continue
             clean="${subject% \[upptime\]}"
             commit_url="https://github.com/${{ github.repository }}/commit/${sha}"
-            payload=$(jq -n --arg text "$(printf '*%s*\n%s' "${clean}" "${commit_url}")" '{"text": $text}')
+            # Page the channel only on bad news — down or degraded.
+            # Recoveries (is up) post quietly. Match on text rather than
+            # emoji bytes since the runner's grep mishandles UTF-8 emoji.
+            mention=""
+            if [[ "$clean" == *" is down ("* || "$clean" == *" is degraded ("* ]]; then
+              mention="<!channel> "
+            fi
+            payload=$(jq -n --arg text "$(printf '%s*%s*\n%s' "${mention}" "${clean}" "${commit_url}")" '{"text": $text}')
             http_code=$(curl -s -o /dev/null -w "%{http_code}" \
               -X POST "${SLACK_WEBHOOK_URL}" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
Add `<!channel>` (Slack `@channel` mention) to uptime alerts for bad news only.

**Behavior:**
| Event | Pings @channel |
|---|---|
| 🟥 site is down | ✅ |
| 🟨 site is degraded | ✅ |
| 🟩 site is up (recovery) | — silent |

Match on text patterns (` is down (` / ` is degraded (`) rather than emoji bytes, since the runner's grep mishandles UTF-8 emoji.

**Resulting Slack message format:**
```
<!channel> *🟥 Site Name is down (0 in 0 ms) [skip ci]*
https://github.com/.../commit/<sha>
```