### PR TITLE
feat(monitor): switch Gutta to production (gutta.no), drop staging

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -90,8 +90,11 @@ sites:
     headers:
       - "User-Agent: Mozilla/5.0 (compatible; KilowottUptime/1.0; +https://github.com/Kilowott-HQ/uptime)"
 
-  - name: Gutta Staging
-    url: https://staging.gutta.no
+  - name: Gutta
+    url: https://gutta.no/
+    tags: [production, client-gutta]
+    headers:
+      - "User-Agent: Mozilla/5.0 (compatible; KilowottUptime/1.0; +https://github.com/Kilowott-HQ/uptime)"
 
   # --- Add more sites below as you expand coverage ---
   #

--- a/history/gutta-staging.yml
+++ b/history/gutta-staging.yml
@@ -1,7 +1,0 @@
-url: https://staging.gutta.no
-status: down
-code: 0
-responseTime: 0
-lastUpdated: 2026-05-05T05:35:35.840Z
-startTime: 2026-05-04T07:25:02.065Z
-generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Gutta going live. Replacing the staging entry with production:

| Before | After |
|---|---|
| name: Gutta Staging | name: Gutta |
| url: https://staging.gutta.no | url: https://gutta.no/ |
| _no headers, no tags_ | tags: [production, client-gutta] + standard User-Agent |

Also deletes the orphaned `history/gutta-staging.yml` (the rename creates a new `gutta.yml` slug, so the old file would otherwise sit unused with stale 'down' status).

After merge: next CI run will write `history/gutta.yml` and the dashboard reflects the new site. If gutta.no is genuinely up, no Slack ping. If it returns non-200, you'll get the @channel down alert.