### PR TITLE
feat(notify): page @channel on recovery too + strip [skip ci] from message

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -70,15 +70,15 @@ jobs:
           failed=0
           while IFS='|' read -r sha subject; do
             [ -z "$sha" ] && continue
+            # Strip Upptime's trailing tags so the Slack message is clean.
+            # Subject format: "🟥 Site is down (0 in 0 ms) [skip ci] [upptime]"
             clean="${subject% \[upptime\]}"
+            clean="${clean% \[skip ci\]}"
             commit_url="https://github.com/${{ github.repository }}/commit/${sha}"
-            # Page the channel only on bad news — down or degraded.
-            # Recoveries (is up) post quietly. Match on text rather than
-            # emoji bytes since the runner's grep mishandles UTF-8 emoji.
-            mention=""
-            if [[ "$clean" == *" is down ("* || "$clean" == *" is degraded ("* ]]; then
-              mention="<!channel> "
-            fi
+            # Always page @channel — every state-change commit is a real
+            # transition (down, degraded, OR recovery) and the team should
+            # know about all of them.
+            mention="<!channel> "
             payload=$(jq -n --arg text "$(printf '%s*%s*\n%s' "${mention}" "${clean}" "${commit_url}")" '{"text": $text}')
             http_code=$(curl -s -o /dev/null -w "%{http_code}" \
               -X POST "${SLACK_WEBHOOK_URL}" \


### PR DESCRIPTION
Two refinements:

1. **`@channel` on all state changes** — recoveries (🟩 up after an outage) now also ping. The team should know an incident is resolved, not just that one started. Down, degraded, and up all page.

2. **Strip `[skip ci]`** — the Slack message no longer shows the GitHub-Actions-internal marker. Cleaner alert text.

**Result:**
```
<!channel> *🟩 Site Name is up (200 in 110 ms)*
https://github.com/.../commit/<sha>
```
(versus the old `...is up (200 in 110 ms) [skip ci]` — same content, less noise.)