### PR TITLE
fix(workflows): pin all upptime-monitor uses to v1.41.0 (Node compat)

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -33,20 +33,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.1
+        uses: upptime/uptime-monitor@v1.41.0  # pinned — see uptime.yml comment
         with:
           command: "readme"
         env:


### PR DESCRIPTION
Static Site CI just failed with the same NODE_MODULE_VERSION mismatch we hit on `uptime.yml`. Five other workflows still use unpinned `v1.41.1` and will hit it on their next scheduled run. Pinning all to v1.41.0.

| File | Uses pinned |
|---|---|
| graphs.yml | 1 |
| response-time.yml | 1 |
| setup.yml | 4 |
| site.yml | 1 (was breaking the static site rebuild) |
| summary.yml | 1 |

`uptime.yml` was already pinned. `update-template.yml` left at `@master` since pinning would defeat its template-update purpose — accepted that it'll fail until upstream Upptime ships a Node-24-compatible release.

After merge, I'll trigger Static Site CI again to rebuild the status page and clear the stale 'Active incidents' display.