### PR TITLE
feat(alerts): add UTC timestamp to Slack, drop commit URL

### DIFF
--- a/.github/workflows/confirm-down-alerts.yml
+++ b/.github/workflows/confirm-down-alerts.yml
@@ -102,9 +102,10 @@ jobs:
             clean="${subject% \[upptime\]}"
             clean="${clean% \[skip ci\]}"
             mention="<!channel> "
-            payload=$(jq -n --arg text "$(printf '%s*%s*\n%s' "${mention}" "${clean}" "${commit_url}")" '{"text": $text}')
+            first_seen_human=$(date -u -d "$first_seen" +"%Y-%m-%d %H:%M:%S UTC")
+            payload=$(jq -n --arg text "$(printf '%s*%s*\nDetected: %s' "${mention}" "${clean}" "${first_seen_human}")" '{"text": $text}')
             if [ "${{ inputs.dry_run }}" = "true" ]; then
-              echo "[DRY-RUN] would POST to Slack: ${clean} | commit_url=${commit_url}"
+              echo "[DRY-RUN] would POST to Slack: ${clean} | first_seen=${first_seen_human}"
               echo "[DRY-RUN] payload: ${payload}"
               http_code=200
             else

--- a/.github/workflows/uptime-playwright.yml
+++ b/.github/workflows/uptime-playwright.yml
@@ -282,9 +282,10 @@ jobs:
 
             clean="${subject% \[upptime\]}"
             clean="${clean% \[skip ci\]}"
-            commit_url="https://github.com/${{ github.repository }}/commit/${sha}"
             mention="<!channel> "
-            payload=$(jq -n --arg text "$(printf '%s*%s*\n%s' "${mention}" "${clean}" "${commit_url}")" '{"text": $text}')
+            flip_iso=$(git show -s --format=%cI "$sha")
+            flip_time=$(date -u -d "$flip_iso" +"%Y-%m-%d %H:%M:%S UTC")
+            payload=$(jq -n --arg text "$(printf '%s*%s*\nDetected: %s' "${mention}" "${clean}" "${flip_time}")" '{"text": $text}')
             http_code=$(curl -s -o /dev/null -w "%{http_code}" \
               --max-time 30 --retry 3 --retry-delay 5 --retry-connrefused \
               -X POST "${SLACK_WEBHOOK_URL}" \

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -188,9 +188,10 @@ jobs:
 
             clean="${subject% \[upptime\]}"
             clean="${clean% \[skip ci\]}"
-            commit_url="https://github.com/${{ github.repository }}/commit/${sha}"
             mention="<!channel> "
-            payload=$(jq -n --arg text "$(printf '%s*%s*\n%s' "${mention}" "${clean}" "${commit_url}")" '{"text": $text}')
+            flip_iso=$(git show -s --format=%cI "$sha")
+            flip_time=$(date -u -d "$flip_iso" +"%Y-%m-%d %H:%M:%S UTC")
+            payload=$(jq -n --arg text "$(printf '%s*%s*\nDetected: %s' "${mention}" "${clean}" "${flip_time}")" '{"text": $text}')
             http_code=$(curl -s -o /dev/null -w "%{http_code}" \
               --max-time 30 --retry 3 --retry-delay 5 --retry-connrefused \
               -X POST "${SLACK_WEBHOOK_URL}" \


### PR DESCRIPTION
## Summary
- Adds a human-readable UTC timestamp (`Detected: 2026-07-04 12:34:56 UTC`) to every Slack alert
- Removes the GitHub commit URL from the Slack message (CEO request — only the alert itself matters)

## Files changed (3, per-file commit each)
- `.github/workflows/uptime.yml` — immediate state-flip path
- `.github/workflows/uptime-playwright.yml` — immediate state-flip path (playwright sites)
- `.github/workflows/confirm-down-alerts.yml` — deferred code:0/5xx confirm path

## Timestamp source
- **uptime.yml / uptime-playwright.yml**: commit `%cI` of the Upptime flip commit (accurate to when Upptime recorded the state change)
- **confirm-down-alerts.yml**: existing `$first_seen` marker field (accurate outage-start)

Both converted to `YYYY-MM-DD HH:MM:SS UTC` via `date -u`.

## Not touched
- Twilio WhatsApp POST blocks (already include timestamps)
- Defer-and-confirm gates, marker write/read logic, curl hardening, `$failed` counter
- All Slack curl commands byte-identical

## No Slack noise on merge
- Only touches `.github/workflows/*.yml`. `site-list-changes.yml` and `setup.yml` are gated on `.upptimerc.yml` paths — won't fire.
- Uptime workflows use cron/dispatch triggers, not push — won't fire on merge.

## Isolation from `feat/whatsapp-multi-recipient` (local branch, not yet on origin)
Grep confirmed zero line overlap: multi-recipient touched only Twilio POST blocks, this PR touches only Slack payload assembly. Clean merge when multi-recipient work is finalized.